### PR TITLE
new_release: Announcement releases in slack

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -38,3 +38,4 @@ The release of Flatcar Container Linux <VERSION> [<VERSION> ...] is planned for 
 - [ ] Update CloudFormation templates ()
 - [ ] Release package published in Nebraska ()
 - [ ] Send announcement to Mailing Lists, and tweet out! (@miao0miao, @ahrkrak)
+- [ ] Brief version announcement in slack (k8s slack #flatcar)


### PR DESCRIPTION
Now that we have a slack channel, it seems like a good idea to announce the releases in slack.
This will allow for discussions around fixed issues.