### PR TITLE
github/pr-template: add checkbox for image differences

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,3 +11,4 @@
 [Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]
 
 - [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
+- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.


### PR DESCRIPTION
during the PR review, we should enforce the check of missing binaries, config files or any other relevant files.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>
